### PR TITLE
Generation data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const frontmatter = require('./frontmatter');
  */
 module.exports = (options, ctx) => {
   const {
+    readyCallback = () => {},
     generatedCallback = () => {},
   } = options;
 
@@ -29,6 +30,10 @@ module.exports = (options, ctx) => {
 
     async ready() {
       updates = frontmatter.collectUpdateInfo(ctx.pages);
+
+      if (typeof readyCallback === 'function') {
+        readyCallback(updates);
+      }
     },
 
     clientDynamicModules() {

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,10 @@ const frontmatter = require('./frontmatter');
  * @return {PluginOptionAPI}
  */
 module.exports = (options, ctx) => {
+  const {
+    generatedCallback = () => {},
+  } = options;
+
   const config = {
     newInfoThresholdDays: options.newInfoThresholdDays || null,
   };
@@ -38,6 +42,12 @@ module.exports = (options, ctx) => {
           content: `export default ${JSON.stringify(updates, null, 2)}`,
         },
       ];
+    },
+
+    async generated() {
+      if (typeof generatedCallback === 'function') {
+        generatedCallback(updates);
+      }
     },
   };
 };


### PR DESCRIPTION
Provides callback options to get update info data and make use of them as generation data:

- `readyCallback`: called when `ready` hook was executed
- `generatedCallback`: called when `generated` hook was executed